### PR TITLE
Fix: GithubGraphWrapper

### DIFF
--- a/src/airas/retrieve_base_paper_subgraph/retrieve_base_paper_subgraph.py
+++ b/src/airas/retrieve_base_paper_subgraph/retrieve_base_paper_subgraph.py
@@ -340,8 +340,8 @@ if __name__ == "__main__":
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/researchgraph/data"
 
-    github_repository = "auto-res2/experiment_script_matsuzawa"
-    branch_name = "base-branch"
+    github_repository = "auto-res2/test27"
+    branch_name = "test"
     input = {
         "base_queries": ["transformer"],
     }

--- a/src/airas/utils/github_utils/graph_wrapper.py
+++ b/src/airas/utils/github_utils/graph_wrapper.py
@@ -117,9 +117,18 @@ class GithubGraphWrapper:
 
     def _prepare_branch(self, state: dict[str, Any]) -> dict[str, Any]:
         original_state = state.get("original_state", {})
-        input_state = {k: v for k, v in state.items() if k != "original_state"}
+        user_input_state = {k: v for k, v in state.items() if k != "original_state"}
 
-        input_conflict = any(k in original_state for k in input_state)  # NOTE: If the key for this newly passed input is a duplicate
+        if not self.perform_download:
+            final_branch = self._create_branch_name()
+            logger.info(f"perform_download is set to False; creating a new branch for safety: {final_branch}")
+            return {
+                "original_state": original_state,
+                "user_input_state": user_input_state,
+                "branch_name": final_branch,
+            }
+
+        input_conflict = any(k in original_state for k in user_input_state)  # NOTE: If the key for this newly passed input is a duplicate
         output_conflict = any(key in original_state for key in self.output_state_keys)
         final_branch = self.branch_name
 
@@ -132,15 +141,15 @@ class GithubGraphWrapper:
 
         return {
             "original_state": original_state,
-            "input_state": input_state,
+            "user_input_state": user_input_state,
             "branch_name": final_branch,
         }
 
     # @time_node("wrapper", "run_subgraph")
     def _run_subgraph(self, state: dict[str, Any]) -> dict[str, Any]:
         original_state = state.get("original_state") or {}
-        input_state = state.get("input_state") if "input_state" in state else state
-        merged_input_state = self._deep_merge(original_state, input_state)
+        user_input_state = state.get("user_input_state") if "user_input_state" in state else state
+        merged_input_state = self._deep_merge(original_state, user_input_state)
         branch_name = state.get("branch_name", self.branch_name)
 
         state_for_subgraph = {
@@ -212,9 +221,9 @@ class GithubGraphWrapper:
             wrapper.add_edge(prev, "download_from_github")
             prev = "download_from_github"
 
-            wrapper.add_node("prepare_branch", self._prepare_branch)
-            wrapper.add_edge(prev, "prepare_branch")
-            prev = "prepare_branch"
+        wrapper.add_node("prepare_branch", self._prepare_branch)
+        wrapper.add_edge(prev, "prepare_branch")
+        prev = "prepare_branch"
 
         wrapper.add_node("run_subgraph", self._run_subgraph)
         wrapper.add_edge(prev, "run_subgraph")
@@ -275,9 +284,9 @@ def create_wrapped_subgraph(
                 public_branch=public_branch,
             )
 
-        def run(self, inputs: dict[str, Any] = {}) -> dict[str, Any]:
+        def run(self, use_input: dict[str, Any] = {}) -> dict[str, Any]:
             graph = self.build_graph()
             config = {"recursion_limit": 300}  # NOTE:
-            return graph.invoke(inputs, config=config)
+            return graph.invoke(use_input, config=config)
 
     return GithubGraphRunner


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Closes #365  <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.

---

# Background & Purpose
Previously, uploading to GitHub always returned `success` even if it failed internally.
Also, when `perform_download=False`, branches could be overwritten unsafely without conflict checking on account of  `research_history.json` is not retrieved.
This PR fixes these issues to ensure reliable upload status and safe branch creation.
 
# Changes
The following features have been modified:
1. [GitHub Upload Handling]: Add precise success/failure detection after uploading.
2. [Branch Management]: Always create a new branch when `perform_download=False`.
3. [Key Renaming]: Rename `input_state` to `user_input_state` for clarity.

Details of the implementation are described below:

<details>
<summary><code>1. src/airas/utils/github_utils/github_file_io.py</code></summary>

 **Implementation Overview**
- In `_upload_file_bytes_to_github()`:
  - When attempting to upload a file, first fetch existing file metadata from GitHub.
  - If the existing file cannot be fetched (response is `None` or not a `dict`), log an error and immediately return `False`.
  - Perform a PUT request to upload the file.
  - After the PUT, check if the response is a valid dictionary and verify that it does not contain an error `message` field.
  - Only if all checks pass, return `True`. 

- In `upload_to_github()`:
  - After encoding the input data, call `_upload_file_bytes_to_github()` and check its boolean result (`ok`).
  - If the main upload or any extra file upload fails (`ok == False`), set the overall upload result `success = False`.

</details>

<details>
<summary><code>2. src/airas/utils/github_utils/graph_wrapper.py</code></summary>

 **Implementation Overview**
- In `_prepare_branch`, always create a new branch if `perform_download=False`.
- Rename `input_state` to `user_input_state` to distinguish it from the original GitHub state.
- Ensure `prepare_branch` is always called, even when skipping downloads.

</details>

## Execution Environment
Tests were executed in the following directory:
 - Command executed:
  ```bash
    uv run python /workspaces/airas/src/airas/retrieve_base_paper_subgraph/retrieve_base_paper_subgraph.py
  ```
<details>
<summary>Execution Results</summary>

- The following is the result of a run on a repository I do not have modification privileges on.

```bash
...
[INFO] airas.utils.execution_timers: [retrieve_base_paper_subgraph._base_select_best_paper_node] End    Execution Time:  1.0557 seconds
[INFO] airas.utils.github_utils.github_file_io: [GitHub I/O] Uploading state to: .research/research_history.json
[INFO] airas.utils.api_request_handler: Requests to endpoints:https://api.github.com/repos/auto-res2/test27/contents/.research/research_history.json
[WARNING] airas.utils.api_request_handler: Error during API request: 404 Client Error: Not Found for url: https://api.github.com/repos/auto-res2/test27/contents/.research/research_history.json?ref=test-retrievebasepapersubgraph-20250428-071918
[INFO] airas.utils.api_request_handler: API request successful on attempt 1.
[ERROR] airas.utils.github_utils.github_file_io: Cannot fetch existing file info for .research/research_history.json on test-retrievebasepapersubgraph-20250428-071918
[INFO] airas.utils.github_utils.graph_wrapper: Updated research_history.json.
[INFO] airas.utils.github_utils.graph_wrapper: Check here：https://github.com/auto-res2/test27/blob/test-retrievebasepapersubgraph-20250428-071918/.research/research_history.json
result: {'github_upload_success': False}
```
</details>